### PR TITLE
feat(be): create model apis for admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kisia-project
 
 ## KISIA 제2회 정보보호 개발자 Hackathon (2024)
+
 - 팀명: 율스 (URLS)
 - 주제: 일상생활 속 정보보호
 - 프로젝트: 악성 URL 탐지 서비스 (Chrome Extension)
@@ -10,6 +11,7 @@
 <img src="./extension/image/text-logo.png" width="100">
 
 ### 기능
+
 1. Database Check
    - 악성 URL 모아 구축한 율스만의 database
    - 계속해서 쌓여 나가는 방식으로 종합적 DB 구축
@@ -22,6 +24,7 @@
    - 정적, 동적 모델을 통한 분석
 
 ### 기술 스택
+
 - Frontend: HTML, CSS, JavaScript
 - Backend: Python, Flask, NestJS, PostgreSQL, CI/CD
 - AI: LSTM, b-LSTM, CodeBERT, Jalangi, NLP, Random Forest
@@ -32,5 +35,29 @@
   - Universit of Maribor malicious url dataset
 
 ### Demo
+
 - [율스 악성 URL 탐지 서비스 탐지 시연 영상](https://drive.google.com/file/d/1MR6lOnnYuWg-IO3W-muJ0djdQdglDErT/view?usp=drive_link)
 - [율스 악성 URL 탐지 서비스 미탐지 시연 영상](https://drive.google.com/file/d/1UIsQsFgGIL_0CFuzHnU2InUrbaD2Cp_s/view?usp=sharing)
+
+## Notes about running the URLS
+
+### flask server
+
+- node version 12 and 14 are required due to the tools used in the project
+  - node version 12 for `jalangi2`
+    - set the project to use node version 12
+  - node version 14 for `prettier`
+    - version will change automatically to 14 when running prettier
+- You can use `nvm` to manage node versions
+```bash
+   nvm install 12
+   nvm use 12
+```
+
+### nestjs server
+
+- needs node version 20
+```bash
+   nvm install 20
+   nvm use 20
+```

--- a/backend/AI/requirements.txt
+++ b/backend/AI/requirements.txt
@@ -40,6 +40,7 @@ optimum==1.21.4
 packaging==24.1
 pandas==2.2.2
 protobuf==5.27.3
+psycopg2==2.9.9
 pyarrow==17.0.0
 pybind11==2.13.5
 pyee==11.1.0

--- a/backend/extension/prisma/migrations/20240929232942_restructure_db/migration.sql
+++ b/backend/extension/prisma/migrations/20240929232942_restructure_db/migration.sql
@@ -1,0 +1,82 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `accessedAt` on the `History` table. All the data in the column will be lost.
+  - You are about to drop the column `urlId` on the `History` table. All the data in the column will be lost.
+  - The primary key for the `Url` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `numFeedback` on the `Url` table. All the data in the column will be lost.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `expiration` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the `Announcements` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `detectedBy` to the `History` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `isMalicious` to the `History` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `url` to the `History` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "History" DROP CONSTRAINT "History_urlId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "History" DROP CONSTRAINT "History_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "History" DROP COLUMN "accessedAt",
+DROP COLUMN "urlId",
+ADD COLUMN     "confidenceScore" DOUBLE PRECISION,
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "detectedBy" "DETECTOR" NOT NULL,
+ADD COLUMN     "isMalicious" BOOLEAN NOT NULL,
+ADD COLUMN     "url" TEXT NOT NULL,
+ALTER COLUMN "userId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "Url" DROP CONSTRAINT "Url_pkey",
+DROP COLUMN "numFeedback",
+ADD COLUMN     "dynamicResult" BOOLEAN,
+ADD COLUMN     "falseNeg" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "staticResult" BOOLEAN,
+ADD COLUMN     "urlResult" BOOLEAN,
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "Url_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "Url_id_seq";
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+DROP COLUMN "expiration",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "User_id_seq";
+
+-- DropTable
+DROP TABLE "Announcements";
+
+-- CreateTable
+CREATE TABLE "ConfusionMatrix" (
+    "id" SERIAL NOT NULL,
+    "modelType" "DETECTOR" NOT NULL,
+    "truePos" INTEGER NOT NULL DEFAULT 0,
+    "trueNeg" INTEGER NOT NULL DEFAULT 0,
+    "falsePos" INTEGER NOT NULL DEFAULT 0,
+    "falseNeg" INTEGER NOT NULL DEFAULT 0,
+    "f1Score" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConfusionMatrix_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RequestSummary" (
+    "id" SERIAL NOT NULL,
+    "period" TEXT NOT NULL,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "totalRequests" INTEGER NOT NULL,
+    "aiRequests" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RequestSummary_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "History" ADD CONSTRAINT "History_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/extension/prisma/migrations/20240930020215_minor_adjustments_for_url/migration.sql
+++ b/backend/extension/prisma/migrations/20240930020215_minor_adjustments_for_url/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - The primary key for the `Url` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `Url` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Url" DROP CONSTRAINT "Url_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ALTER COLUMN "accessCount" SET DEFAULT 1,
+ADD CONSTRAINT "Url_pkey" PRIMARY KEY ("id");

--- a/backend/extension/prisma/migrations/20241004071151_add_confusion_hit_rate_table/migration.sql
+++ b/backend/extension/prisma/migrations/20241004071151_add_confusion_hit_rate_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "ConfusionHitRate" (
+    "id" SERIAL NOT NULL,
+    "confidenceRange" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ConfusionHitRate_pkey" PRIMARY KEY ("id")
+);

--- a/backend/extension/prisma/migrations/20241004071359_fix_to_confidence_hit_rate_table/migration.sql
+++ b/backend/extension/prisma/migrations/20241004071359_fix_to_confidence_hit_rate_table/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ConfusionHitRate` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "ConfusionHitRate";
+
+-- CreateTable
+CREATE TABLE "ConfidenceHitRate" (
+    "id" SERIAL NOT NULL,
+    "confidenceRange" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ConfidenceHitRate_pkey" PRIMARY KEY ("id")
+);

--- a/backend/extension/prisma/migrations/20241004075050_add_unique_to_confidence_range/migration.sql
+++ b/backend/extension/prisma/migrations/20241004075050_add_unique_to_confidence_range/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[confidenceRange]` on the table `ConfidenceHitRate` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "ConfidenceHitRate_confidenceRange_key" ON "ConfidenceHitRate"("confidenceRange");

--- a/backend/extension/prisma/migrations/20241005060851_fix_model_type_in_confusion_matrix/migration.sql
+++ b/backend/extension/prisma/migrations/20241005060851_fix_model_type_in_confusion_matrix/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[modelType]` on the table `ConfusionMatrix` will be added. If there are existing duplicate values, this will fail.
+  - Changed the type of `modelType` on the `ConfusionMatrix` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "ConfusionMatrix" DROP COLUMN "modelType",
+ADD COLUMN     "modelType" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConfusionMatrix_modelType_key" ON "ConfusionMatrix"("modelType");

--- a/backend/extension/prisma/schema.prisma
+++ b/backend/extension/prisma/schema.prisma
@@ -88,3 +88,10 @@ model RequestSummary {
   aiRequests    Int
   createdAt     DateTime @default(now())
 }
+
+model ConfidenceHitRate {
+  id              Int      @id @default(autoincrement())
+  confidenceRange String
+  count           Int
+  updatedAt       DateTime @updatedAt
+}

--- a/backend/extension/prisma/schema.prisma
+++ b/backend/extension/prisma/schema.prisma
@@ -42,14 +42,14 @@ model User {
 }
 
 model Url {
-  id              String   @id @default(uuid())
+  id              Int      @id @default(autoincrement())
   url             String   @unique
   isMalicious     Boolean
   detectedBy      DETECTOR @default(DATABASE)
   urlResult       Boolean? // url model result
   staticResult    Boolean? // static model result
   dynamicResult   Boolean? // dynamic model result
-  accessCount     Int      @default(0) // number of times this url has been asked for verification
+  accessCount     Int      @default(1) // number of times this url has been asked for verification
   falsePos        Int      @default(0) // number of times it was reported as a false positives
   falseNeg        Int      @default(0) // number of times it was reported as a false negatives
   confidenceScore Float? // used with ai models

--- a/backend/extension/prisma/schema.prisma
+++ b/backend/extension/prisma/schema.prisma
@@ -91,7 +91,7 @@ model RequestSummary {
 
 model ConfidenceHitRate {
   id              Int      @id @default(autoincrement())
-  confidenceRange String
+  confidenceRange String   @unique
   count           Int
   updatedAt       DateTime @updatedAt
 }

--- a/backend/extension/prisma/schema.prisma
+++ b/backend/extension/prisma/schema.prisma
@@ -71,12 +71,12 @@ model History {
 
 model ConfusionMatrix {
   id        Int      @id @default(autoincrement())
-  modelType DETECTOR
+  modelType String   @unique // static, dynamic, ai
   truePos   Int      @default(0)
   trueNeg   Int      @default(0)
   falsePos  Int      @default(0)
   falseNeg  Int      @default(0)
-  f1Score   Float?
+  updatedAt DateTime @updatedAt
   createdAt DateTime @default(now())
 }
 

--- a/backend/extension/prisma/schema.prisma
+++ b/backend/extension/prisma/schema.prisma
@@ -26,12 +26,11 @@ enum DETECTOR {
 }
 
 model User {
-  id            Int       @id @default(autoincrement())
+  id            String    @id @default(uuid())
   username      String    @unique
   password      String // hashed password
   email         String    @unique
   type          UserTypes @default(STANDARD_USER)
-  expiration    DateTime? // expiration date for premium users
   dailyRequests Int       @default(0) // number of requests made by the user in a day; resets at 00:00
   requestsLimit Int       @default(3) // number of requests allowed per day for free users
   lastLogin     DateTime? // last login time
@@ -43,35 +42,49 @@ model User {
 }
 
 model Url {
-  id               Int      @id @default(autoincrement())
-  url              String   @unique
-  isMalicious      Boolean
-  accessCount      Int      @default(0) // number of times this url has been asked for verification
-  detectedBy       DETECTOR @default(DATABASE)
-  falsePos         Int      @default(0) // number of times it was reported as a false positives
+  id              String   @id @default(uuid())
+  url             String   @unique
+  isMalicious     Boolean
+  detectedBy      DETECTOR @default(DATABASE)
+  urlResult       Boolean? // url model result
+  staticResult    Boolean? // static model result
+  dynamicResult   Boolean? // dynamic model result
+  accessCount     Int      @default(0) // number of times this url has been asked for verification
+  falsePos        Int      @default(0) // number of times it was reported as a false positives
+  falseNeg        Int      @default(0) // number of times it was reported as a false negatives
   confidenceScore Float? // used with ai models
-  numFeedback      Int      @default(0) // number of feedbacks received (used to count false positives and negatives)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
-
-  // many-to-many relation with User
-  users History[]
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 }
 
 model History {
-  id         Int      @id @default(autoincrement())
-  userId     Int
-  urlId      Int
-  accessedAt DateTime @default(now())
+  id              Int      @id @default(autoincrement())
+  userId          String
+  url             String
+  isMalicious     Boolean
+  detectedBy      DETECTOR
+  confidenceScore Float?
+  createdAt       DateTime @default(now())
 
   user User @relation(fields: [userId], references: [id])
-  url  Url  @relation(fields: [urlId], references: [id])
 }
 
-model Announcements{
+model ConfusionMatrix {
   id        Int      @id @default(autoincrement())
-  title     String
-  content   String
+  modelType DETECTOR
+  truePos   Int      @default(0)
+  trueNeg   Int      @default(0)
+  falsePos  Int      @default(0)
+  falseNeg  Int      @default(0)
+  f1Score   Float?
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+}
+
+model RequestSummary {
+  id            Int      @id @default(autoincrement())
+  period        String // day, week, month
+  periodStart   DateTime
+  totalRequests Int
+  aiRequests    Int
+  createdAt     DateTime @default(now())
 }

--- a/backend/extension/src/admin/admin.controller.ts
+++ b/backend/extension/src/admin/admin.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('admin')
+export class AdminController {}

--- a/backend/extension/src/admin/admin.module.ts
+++ b/backend/extension/src/admin/admin.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { ModelModule } from './model/model.module';
+
+@Module({
+  controllers: [AdminController],
+  imports: [ModelModule],
+})
+export class AdminModule {}

--- a/backend/extension/src/admin/model/model.controller.ts
+++ b/backend/extension/src/admin/model/model.controller.ts
@@ -1,0 +1,76 @@
+import {
+    BadRequestException,
+    Controller,
+    Get,
+    Logger,
+    Post,
+    Query,
+  } from '@nestjs/common';
+  import { ModelService } from './model.service';
+  
+  @Controller('admin/model')
+  export class ModelController {
+    private readonly logger = new Logger(ModelController.name);
+    constructor(private readonly modelService: ModelService) {}
+  
+    // test api
+    @Get('test')
+    async test() {
+      return {
+        statusCode: 200,
+        message: 'Test successful',
+      };
+    }
+  
+    // confusion matrix logic
+    @Get('confusion-matrix')
+    async getConfusionMatrix(@Query('model') model?: string) {
+      const validModels = ['url', 'dynamic', 'static'];
+  
+      if (model && !validModels.includes(model)) {
+        this.logger.error(`Invalid model for confusion matrix: ${model}`);
+        throw new BadRequestException(
+          'Invalid model for confusion matrix. Must be url, dynamic, or static',
+        );
+      }
+  
+      try {
+        this.logger.log(`Getting confusion matrix`);
+  
+        if (model) {
+          return {
+            statusCode: 200,
+            message: 'Successfully retrieved confusion matrix',
+            data: await this.modelService.getConfusionMatrix(model),
+          };
+        } else {
+          return {
+            statusCode: 200,
+            message: 'Successfully retrieved confusion matrix',
+            data: await this.modelService.getConfusionMatrix(),
+          };
+        }
+      } catch (error) {
+        this.logger.error(`Error getting confusion matrix`, error);
+        throw new BadRequestException('Error getting confusion matrix');
+      }
+    }
+  
+    // confidence hit rate logic
+    @Get('confidence-hit-rate')
+    async getConfidenceHitRate() {
+      try {
+        this.logger.log(`Getting confidence hit rate`);
+  
+        return {
+          statusCode: 200,
+          message: 'Successfully retrieved confidence hit rate',
+          data: await this.modelService.getConfidenceHitRate(),
+        };
+      } catch (error) {
+        this.logger.error(`Error getting confidence hit rate`, error);
+        throw new BadRequestException('Error getting confidence hit rate');
+      }
+    }
+  }
+  

--- a/backend/extension/src/admin/model/model.module.ts
+++ b/backend/extension/src/admin/model/model.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ModelService } from './model.service';
+import { ModelController } from './model.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ModelService],
+  controllers: [ModelController],
+})
+export class ModelModule {}

--- a/backend/extension/src/admin/model/model.service.ts
+++ b/backend/extension/src/admin/model/model.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { count } from 'console';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+
+@Injectable()
+export class ModelService {
+  private readonly logger = new Logger(ModelService.name);
+  constructor(private readonly prismaService: PrismaService) {}
+
+  // confusion matrix logic ========================================
+  async getConfusionMatrix(model?: string) {
+    if (model) {
+      const databaseResult =
+        await this.prismaService.confusionMatrix.findUnique({
+          where: { modelType: model },
+        });
+
+      if (databaseResult) {
+        this.logger.log(`Found confusion matrix for model: ${model}`);
+        return {
+          modelType: databaseResult.modelType,
+          truePositive: databaseResult.truePos,
+          trueNegative: databaseResult.trueNeg,
+          falsePositive: databaseResult.falsePos,
+          falseNegative: databaseResult.falseNeg,
+        };
+      }
+    }else{
+        const databaseResult = await this.prismaService.confusionMatrix.findMany();
+
+        if (databaseResult) {
+          this.logger.log(`Found confusion matrix for all models`);
+          return databaseResult.map((result) => {
+            return {
+              modelType: result.modelType,
+              truePositive: result.truePos,
+              trueNegative: result.trueNeg,
+              falsePositive: result.falsePos,
+              falseNegative: result.falseNeg,
+            };
+          });
+        }
+    }
+  }
+
+  // confidence hit rate logic ========================================
+  async getConfidenceHitRate() {
+    const databaseResult = await this.prismaService.confidenceHitRate.findMany();
+
+    if (databaseResult) {
+      this.logger.log(`Found confidence hit rate for all models`);
+      return databaseResult.map((result) => {
+        return {
+          confidenceRange: result.confidenceRange,
+          count: result.count,
+        };
+      });
+    }
+  }
+}

--- a/backend/extension/src/app.module.ts
+++ b/backend/extension/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from './prisma/prisma.module';
 import { UrlModule } from './url/url.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
-  imports: [PrismaModule, UrlModule],
+  imports: [PrismaModule, UrlModule, AdminModule],
   controllers: [],
   providers: [],
 })


### PR DESCRIPTION
Issue #18 

## changes
- refactored database to support admin APIs
- implementeed model APIs for admin

## Implemented APIs
- `/admin/model/confusion-matrix?model=url|dynamic|static`
- `/admin/model/confidence-hit-rate`

## Bugs
- admin module cannot import model module
    - have to set route in model module as `admin/model` instead of `model`